### PR TITLE
Disabling console logs initially

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -159,7 +159,7 @@ ________________________________________________________________________________
 local SHOW_DEBUG_RAY_LINES: boolean = true
 
 -- Allow RaycastModule to write to the output
-local SHOW_OUTPUT_MESSAGES: boolean = true
+local SHOW_OUTPUT_MESSAGES: boolean = false
 
 -- The tag name. Used for cleanup.
 local DEFAULT_COLLECTION_TAG_NAME: string = "_RaycastHitboxV4Managed"


### PR DESCRIPTION
Hi!

I'm currently having an issue where I have to set **SHOW_OUTPUT_MESSAGES** to false each time I install the library, as otherwise my console is spammed each time a hitbox is created (As I cannot disable logs initially when creating the hitbox, causing the "X attachments found in object" log to appear).

I think it would be an easy fix to just put **SHOW_OUTPUT_MESSAGES** to false by default. If someone wants logs, they can explicitly set hitbox.DebugLog to true after creating the Hitbox.